### PR TITLE
Change mvc routing

### DIFF
--- a/src/SpellsReference/App_Start/RouteConfig.cs
+++ b/src/SpellsReference/App_Start/RouteConfig.cs
@@ -14,9 +14,15 @@ namespace SpellsReference
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
             routes.MapRoute(
-                name: "Default",
-                url: "{controller}/{action}/{id}",
+                name: "MVC",
+                url: "mvc/{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+                );
+
+            routes.MapRoute(
+                name: "Default",
+                url: "",
+                defaults: new { controller = "React", action = "Index" }
             );
         }
     }

--- a/src/SpellsReference/App_Start/RouteConfig.cs
+++ b/src/SpellsReference/App_Start/RouteConfig.cs
@@ -21,7 +21,7 @@ namespace SpellsReference
 
             routes.MapRoute(
                 name: "Default",
-                url: "",
+                url: "{*reaaaaaact}",
                 defaults: new { controller = "React", action = "Index" }
             );
         }

--- a/src/SpellsReference/Scripts/dist/bundle.js
+++ b/src/SpellsReference/Scripts/dist/bundle.js
@@ -374,7 +374,7 @@ eval("\n\nif (false) {} else {\n  module.exports = __webpack_require__(/*! ./cjs
 /*!***************************************************************!*\
   !*** ./node_modules/react-router-dom/esm/react-router-dom.js ***!
   \***************************************************************/
-/*! exports provided: MemoryRouter, Prompt, Redirect, Route, Router, StaticRouter, Switch, __RouterContext, generatePath, matchPath, useHistory, useLocation, useParams, useRouteMatch, withRouter, BrowserRouter, HashRouter, Link, NavLink */
+/*! exports provided: BrowserRouter, HashRouter, Link, NavLink, MemoryRouter, Prompt, Redirect, Route, Router, StaticRouter, Switch, __RouterContext, generatePath, matchPath, useHistory, useLocation, useParams, useRouteMatch, withRouter */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";


### PR DESCRIPTION
Now, all URLs not prefixed with `/mvc/` should be routed to the react pages.